### PR TITLE
Issue-31 Warn the user when missing field data plugins are detected.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the field data framework.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-field-data-framework/compare/v17.4.1...v17.4.0) to see the full source code difference.
 
+### 18.3.1
+- Added "missing plugin" detection logic to the Field Data Plugin Tool.
+
 ### 18.3.0
 - Added support for AQTS 2018.3 plugins
 - See [2018.3 release notes](docs#aqts-20183) for details of new features.

--- a/src/FieldDataPluginTool/FieldDataPluginTool.csproj
+++ b/src/FieldDataPluginTool/FieldDataPluginTool.csproj
@@ -44,6 +44,9 @@
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Humanizer, Version=2.5.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Humanizer.Core.2.5.1\lib\netstandard2.0\Humanizer.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>

--- a/src/FieldDataPluginTool/packages.config
+++ b/src/FieldDataPluginTool/packages.config
@@ -3,6 +3,7 @@
   <package id="Aquarius.SDK" version="18.7.1" targetFramework="net47" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
+  <package id="Humanizer.Core" version="2.5.1" targetFramework="net47" />
   <package id="log4net" version="2.0.8" targetFramework="net47" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net462" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net462" />


### PR DESCRIPTION
If a plugin is reported as installed by the Provisioning API, yet it fails to exist on the app server, mark the plugin as missing.

Prompt the user to delete missing plugins from the API to make the system sane again.