### PR TITLE
Issue-36: Make the tools resilient against filename changes.

### DIFF
--- a/src/FieldDataPluginTool/Program.cs
+++ b/src/FieldDataPluginTool/Program.cs
@@ -53,7 +53,8 @@ namespace FieldDataPluginTool
 
         private static byte[] LoadEmbeddedResource(string path)
         {
-            var resourceName = $"{GetProgramName()}.{path}";
+            // ReSharper disable once PossibleNullReferenceException
+            var resourceName = $"{MethodBase.GetCurrentMethod().DeclaringType.Namespace}.{path}";
 
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
             {
@@ -62,11 +63,6 @@ namespace FieldDataPluginTool
 
                 return stream.ReadFully();
             }
-        }
-
-        private static string GetProgramName()
-        {
-            return Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location);
         }
     }
 }

--- a/src/PluginPackager/Program.cs
+++ b/src/PluginPackager/Program.cs
@@ -53,7 +53,8 @@ namespace PluginPackager
 
         private static byte[] LoadEmbeddedResource(string path)
         {
-            var resourceName = $"{GetProgramName()}.{path}";
+            // ReSharper disable once PossibleNullReferenceException
+            var resourceName = $"{MethodBase.GetCurrentMethod().DeclaringType.Namespace}.{path}";
 
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
             {

--- a/src/PluginTester/Program.cs
+++ b/src/PluginTester/Program.cs
@@ -60,7 +60,8 @@ namespace PluginTester
 
         private static byte[] LoadEmbeddedResource(string path)
         {
-            var resourceName = $"{GetProgramName()}.{path}";
+            // ReSharper disable once PossibleNullReferenceException
+            var resourceName = $"{MethodBase.GetCurrentMethod().DeclaringType.Namespace}.{path}";
 
             using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
             {


### PR DESCRIPTION
Anchor the embedded resource loader to the assembly namespace, not the filename.