### PR TITLE
Issue-47 - Support testing multiple files at once.

### DIFF
--- a/src/PluginTester/Context.cs
+++ b/src/PluginTester/Context.cs
@@ -1,12 +1,15 @@
-﻿using FieldDataPluginFramework.Results;
+﻿using System;
+using System.Collections.Generic;
+using FieldDataPluginFramework.Results;
 
 namespace PluginTester
 {
     public class Context
     {
         public string PluginPath { get; set; }
-        public string DataPath { get; set; }
+        public List<string> DataPaths { get; set; } = new List<string>();
         public string LocationIdentifier { get; set; }
+        public TimeSpan LocationUtcOffset { get; set; } = TimeSpan.FromHours(-8);
         public string JsonPath { get; set; }
         public ParseFileStatus ExpectedStatus { get; set; } = ParseFileStatus.SuccessfullyParsedAndDataValid;
         public string ExpectedError { get; set; }

--- a/src/PluginTester/FieldDataResultsAppender.cs
+++ b/src/PluginTester/FieldDataResultsAppender.cs
@@ -15,27 +15,26 @@ namespace PluginTester
 {
     public class FieldDataResultsAppender : IFieldDataResultsAppender
     {
-        public static LocationInfo CreateDummyLocationInfoByIdentifier(string locationIdentifier)
+        public LocationInfo CreateDummyLocationInfoByIdentifier(string locationIdentifier)
         {
             return CreateDummyLocationInfo(locationIdentifier, $"DummyNameFor-{locationIdentifier}", Guid.Empty);
         }
 
-        public static LocationInfo CreateDummyLocationInfoByUniqueId(Guid uniqueId)
+        private LocationInfo CreateDummyLocationInfoByUniqueId(Guid uniqueId)
         {
             return CreateDummyLocationInfo($"DummyIdentifierFor-{uniqueId:N}", $"DummyNameFor-{uniqueId:N}", uniqueId);
         }
 
-        private static LocationInfo CreateDummyLocationInfo(string identifier, string name, Guid uniqueId)
+        private LocationInfo CreateDummyLocationInfo(string identifier, string name, Guid uniqueId)
         {
             const long dummyLocationId = 0;
-            const double dummyUtcOffset = 0;
 
             var locationInfo = InternalConstructor<LocationInfo>.Invoke(
                 name,
                 identifier,
                 dummyLocationId,
                 uniqueId,
-                dummyUtcOffset);
+                UtcOffset.TotalHours);
 
             if (KnownLocations.Any(l => l.LocationIdentifier == identifier))
                 throw new ArgumentException($"Can't add duplicate location for Identifier='{identifier}'");
@@ -48,6 +47,7 @@ namespace PluginTester
         private static readonly List<LocationInfo> KnownLocations = new List<LocationInfo>();
 
         public LocationInfo ForcedLocationInfo { get; set; }
+        public TimeSpan UtcOffset { get; set; }
 
         public AppendedResults AppendedResults { get; } = new AppendedResults
         {

--- a/src/PluginTester/PluginTester.csproj
+++ b/src/PluginTester/PluginTester.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Option.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tester.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="log4net.config" />

--- a/src/PluginTester/Readme.md
+++ b/src/PluginTester/Readme.md
@@ -19,8 +19,9 @@ usage: PluginTester [-option=value] ...
 Supported -option=value settings (/option=value works too):
 
   -Plugin               Path to the plugin assembly to debug
-  -Data                 Path to the data file to be parsed
+  -Data                 Path to the data file to be parsed. Can be set more than once.
   -Location             Optional location identifier context
+  -UtcOffset            UTC offset in .NET TimeSpan format. [default: -08:00:00]
   -Json                 Optional path to write the appended results as JSON
   -ExpectedError        Expected error message
   -ExpectedStatus       Expected parse status. One of SuccessfullyParsedButDataInvalid, SuccessfullyParsedAndDataValid, CannotParse [default: SuccessfullyParsedAndDataValid]

--- a/src/PluginTester/Tester.cs
+++ b/src/PluginTester/Tester.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FieldDataPluginFramework;
+using FieldDataPluginFramework.Results;
+using log4net;
+using ServiceStack;
+using ServiceStack.Text;
+using IFrameworkLogger = FieldDataPluginFramework.ILog;
+using ILog = log4net.ILog;
+
+namespace PluginTester
+{
+    public class Tester
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public Context Context { get; set; }
+
+        private IFieldDataPlugin Plugin { get; set; }
+        private IFrameworkLogger Logger { get; set; }
+        private int FailedCount { get; set; }
+
+        public void Run()
+        {
+            Plugin = LoadPlugin();
+            Logger = CreateLogger();
+
+            foreach (var path in Context.DataPaths)
+            {
+                ParseOneFile(path);
+            }
+
+            if (FailedCount > 0)
+            {
+                throw new ExpectedException($"{FailedCount} files of {Context.DataPaths.Count} failed to parse as expected, check the log for details.");
+            }
+
+            if (Context.DataPaths.Count > 1)
+            {
+                Log.Info($"{Context.DataPaths.Count} files parsed as expected.");
+            }
+        }
+
+        private void ParseOneFile(string path)
+        {
+            using (var stream = LoadDataStream(path))
+            {
+                var appender = new FieldDataResultsAppender
+                {
+                    UtcOffset = Context.LocationUtcOffset
+                };
+
+                var locationInfo = !string.IsNullOrEmpty(Context.LocationIdentifier)
+                    ? appender.CreateDummyLocationInfoByIdentifier(Context.LocationIdentifier)
+                    : null;
+
+                appender.ForcedLocationInfo = locationInfo;
+                appender.AppendedResults.PluginAssemblyQualifiedTypeName = Plugin.GetType().AssemblyQualifiedName;
+
+                try
+                {
+                    var result = string.IsNullOrEmpty(Context.LocationIdentifier)
+                        ? Plugin.ParseFile(stream, appender, Logger)
+                        : Plugin.ParseFile(stream, locationInfo, appender, Logger);
+
+
+                    SaveAppendedResults(path, appender.AppendedResults);
+
+                    SummarizeResults(result, appender.AppendedResults);
+                }
+                catch (ExpectedException)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    Log.Error("Plugin has thrown an error", exception);
+
+                    throw new ExpectedException($"Unhandled plugin exception: {exception.Message}");
+                }
+            }
+        }
+
+        private void SaveAppendedResults(string sourcePath, AppendedResults appendedResults)
+        {
+            if (string.IsNullOrEmpty(Context.JsonPath))
+                return;
+
+            var savePath = Directory.Exists(Context.JsonPath)
+                ? Path.Combine(Context.JsonPath, $"{Path.GetFileName(sourcePath)}.json")
+                : Context.JsonPath;
+
+            Log.Info($"Saving {appendedResults.AppendedVisits.Count} visits data to '{savePath}'");
+
+            File.WriteAllText(savePath, appendedResults.ToJson().IndentJson());
+        }
+
+        private void SummarizeResults(ParseFileResult result, AppendedResults appendedResults)
+        {
+            try
+            {
+                if (result.Status == Context.ExpectedStatus)
+                {
+                    SummarizeExpectedResults(result, appendedResults);
+                }
+                else
+                {
+                    SummarizeFailedResults(result, appendedResults);
+                }
+
+            }
+            catch (ExpectedException e)
+            {
+                if (Context.DataPaths.Count > 1)
+                {
+                    Log.Error(e.Message);
+                    ++FailedCount;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private void SummarizeExpectedResults(ParseFileResult result, AppendedResults appendedResults)
+        {
+            if (result.Parsed)
+            {
+                if (!appendedResults.AppendedVisits.Any())
+                {
+                    throw new ExpectedException("File was parsed but no visits were appended.");
+                }
+
+                Log.Info($"Successfully parsed {appendedResults.AppendedVisits.Count} visits.");
+            }
+            else
+            {
+                var actualError = result.ErrorMessage ?? string.Empty;
+                var expectedError = Context.ExpectedError ?? string.Empty;
+
+                if (!actualError.Equals(expectedError))
+                    throw new ExpectedException(
+                        $"Expected an error message of '{expectedError}' but received '{actualError}' instead.");
+
+                Log.Info($"ParsedResult.Status == {Context.ExpectedStatus} with Error='{Context.ExpectedError}' as expected.");
+            }
+        }
+
+        private void SummarizeFailedResults(ParseFileResult result, AppendedResults appendedResults)
+        {
+            if (result.Parsed)
+                throw new ExpectedException(
+                    $"File was parsed successfully with {appendedResults.AppendedVisits.Count} visits appended.");
+
+            if (result.Status != ParseFileStatus.CannotParse)
+                throw new ExpectedException(
+                    $"Result: Parsed={result.Parsed} Status={result.Status} ErrorMessage={result.ErrorMessage}");
+
+            if (!string.IsNullOrEmpty(result.ErrorMessage))
+            {
+                throw new ExpectedException($"Can't parse '{Context.DataPaths}'. {result.ErrorMessage}");
+            }
+
+            throw new ExpectedException($"File '{Context.DataPaths}' is not parsed by the plugin.");
+        }
+
+        private Stream LoadDataStream(string path)
+        {
+            if (!File.Exists(path))
+                throw new ExpectedException($"Data file '{path}' does not exist.");
+
+            Log.Info($"Loading data file '{path}'");
+
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = new BinaryReader(stream))
+            {
+                return new MemoryStream(reader.ReadBytes((int)stream.Length));
+            }
+        }
+
+        private IFieldDataPlugin LoadPlugin()
+        {
+            var pluginPath = Path.GetFullPath(Context.PluginPath);
+
+            if (!File.Exists(pluginPath))
+                throw new ExpectedException($"Plugin file '{pluginPath}' does not exist.");
+
+            // ReSharper disable once PossibleNullReferenceException
+            var assembliesInPluginFolder = new FileInfo(pluginPath).Directory.GetFiles("*.dll");
+
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                var dll = assembliesInPluginFolder.FirstOrDefault(fi =>
+                    args.Name.StartsWith(Path.GetFileNameWithoutExtension(fi.Name) + ", ",
+                        StringComparison.InvariantCultureIgnoreCase));
+
+                return dll == null ? null : Assembly.LoadFrom(dll.FullName);
+            };
+
+            var assembly = Assembly.LoadFile(pluginPath);
+
+            var pluginTypes = (
+                    from type in assembly.GetTypes()
+                    where typeof(IFieldDataPlugin).IsAssignableFrom(type)
+                    select type
+                ).ToList();
+
+            if (pluginTypes.Count == 0)
+                throw new ExpectedException($"No IFieldDataPlugin plugin implementations found in '{pluginPath}'.");
+
+            if (pluginTypes.Count > 1)
+                throw new ExpectedException($"{pluginTypes.Count} IFieldDataPlugin plugin implementations found in '{pluginPath}'.");
+
+            var pluginType = pluginTypes.Single();
+
+            return Activator.CreateInstance(pluginType) as IFieldDataPlugin;
+        }
+
+        private IFrameworkLogger CreateLogger()
+        {
+            return Log4NetLogger.Create(LogManager.GetLogger(Path.GetFileNameWithoutExtension(Context.PluginPath)));
+        }
+    }
+}


### PR DESCRIPTION
The /Data=path option can now be set more than once, and can accept DOS-style wildcards.
The /Json=path option can now be set to a directory, useful when parsing multiple files at once.

This avoids all the .NET process launch overhead (just over a second of CPU time) when testing the parsing of multiple files.

Also added a /UtcOffset=timespan option to set the UTC offset