### PR TITLE
Issue-75 - Only add a location to the cache if it is missing

### DIFF
--- a/src/FieldVisitHotFolderService/FieldDataResultsAppender.cs
+++ b/src/FieldVisitHotFolderService/FieldDataResultsAppender.cs
@@ -60,7 +60,10 @@ namespace FieldVisitHotFolderService
                     location.UniqueId,
                     location.UtcOffset.ToTimeSpan().TotalHours);
 
-            LocationCache.Add(locationInfo);
+            if (LocationCache.SingleOrDefault(l => l.LocationIdentifier == locationInfo.LocationIdentifier) == null)
+            {
+                LocationCache.Add(locationInfo);
+            }
 
             return locationInfo;
         }


### PR DESCRIPTION
This works around a bug where a location with an underscore in its identifier can match more than one location.