### PR TITLE
Issue-84 - Added /FileScanInterval option, defaulting to 1 minute

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,8 +4,9 @@ This page highlights some changes in the field data framework.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-field-data-framework/compare/v17.4.1...v17.4.0) to see the full source code difference.
 
-### 18.4.15
+### 18.4.16
 - The FieldVisitHotFolderService has a few bug fixes:
+    - [Issue #84](https://github.com/AquaticInformatics/aquarius-field-data-framework/issues/84) - Added periodic file scan at `/FileScanInterval`
     - [Issue #82](https://github.com/AquaticInformatics/aquarius-field-data-framework/issues/82) - Skip visits for unknown locations
     - [Issue #81](https://github.com/AquaticInformatics/aquarius-field-data-framework/issues/81) - Show when the service is running
     - [Issue #80](https://github.com/AquaticInformatics/aquarius-field-data-framework/issues/80) - Capture all logged messages

--- a/src/FieldVisitHotFolderService/Context.cs
+++ b/src/FieldVisitHotFolderService/Context.cs
@@ -16,6 +16,7 @@ namespace FieldVisitHotFolderService
         public string ArchivedFolder { get; set; } = "Archived";
         public string FailedFolder { get; set; } = "Failed";
         public TimeSpan FileQuietDelay { get; set; } = TimeSpan.FromSeconds(5);
+        public TimeSpan FileScanInterval { get; set; } = TimeSpan.FromMinutes(1);
         public int MaximumConnectionAttempts { get; set; } = 3;
         public TimeSpan ConnectionRetryDelay { get; set; } = TimeSpan.FromMinutes(1);
         public MergeMode MergeMode { get; set; } = MergeMode.Skip;

--- a/src/FieldVisitHotFolderService/Program.cs
+++ b/src/FieldVisitHotFolderService/Program.cs
@@ -158,6 +158,13 @@ namespace FieldVisitHotFolderService
                 },
                 new CommandLineOption
                 {
+                    Key = nameof(context.FileScanInterval),
+                    Setter = value => context.FileScanInterval = TimeSpan.Parse(value),
+                    Getter = () => context.FileScanInterval.ToString(),
+                    Description = "Maximum timespan between scanning for new files."
+                },
+                new CommandLineOption
+                {
                     Key = nameof(context.ProcessingFolder),
                     Setter = value => context.ProcessingFolder = value,
                     Getter = () => context.ProcessingFolder,
@@ -260,6 +267,15 @@ namespace FieldVisitHotFolderService
 
             if (context.MaximumConcurrentRequests > upperLimit)
                 throw new ExpectedException($"{nameof(context.MaximumConcurrentRequests)} can't exceed {upperLimit}.");
+
+            if (context.FileScanInterval <= TimeSpan.Zero)
+                throw new ExpectedException($"{nameof(context.FileScanInterval)} must be positive.");
+
+            if (context.FileQuietDelay <= TimeSpan.Zero)
+                throw new ExpectedException($"{nameof(context.FileQuietDelay)} must be positive.");
+
+            if (context.ConnectionRetryDelay <= TimeSpan.Zero)
+                throw new ExpectedException($"{nameof(context.ConnectionRetryDelay)} must be positive.");
         }
 
         private readonly Context _context;

--- a/src/FieldVisitHotFolderService/Readme.md
+++ b/src/FieldVisitHotFolderService/Readme.md
@@ -176,6 +176,7 @@ Supported -option=value settings (/option=value works too):
   -HotFolderPath              The root path to monitor for field visit files.
   -FileMask                   A comma-separated list of file patterns to monitor. [defaults to '*.*' if omitted]
   -FileQuietDelay             Timespan of no file activity before processing begins. [default: 00:00:05]
+  -FileScanInterval           Maximum timespan between scanning for new files. [default: 00:01:00]
   -ProcessingFolder           Move files to this folder during processing. [default: Processing]
   -UploadedFolder             Move files to this folder after successful uploads. [default: Uploaded]
   -PartialFolder              Move files to this folder if when partial uploads are performed to avoid duplicates. [default: PartialUploads]


### PR DESCRIPTION
This should work around any times when the .NET framework fails to report file change events due to heavy loading.