### PR TITLE
Issue-120 - Fix ZIP-with-attachments support in the hot folder service

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the field data framework.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-field-data-framework/compare/v17.4.1...v17.4.0) to see the full source code difference.
 
+### 19.4.4
+- Fixed ZIPs-with-attachments for the FieldVisitHotFolderService
+
 ### 19.4.3
 - Added support for AQTS 2019.4 Update 1 plugins
 - See [2019.4 Update 1 release notes](docs#aqts-20194-update-1---framework-version-27) for details of new features.

--- a/src/Common/ZipLoader.cs
+++ b/src/Common/ZipLoader.cs
@@ -112,11 +112,14 @@ namespace Common
 
                     var pluginDataEntry = rootEntries.First();
 
+                    var pluginDataAttachment = LoadAttachment(pluginDataEntry);
+                    pluginDataAttachment.Path = Path.Combine("PluginData", pluginDataAttachment.Path);
+
                     result = new ZipWithAttachments
                     {
                         PluginDataBytes = LoadAttachment(pluginDataEntry).Content,
-                        Attachments = attachmentEntries
-                            .Select(LoadAttachment)
+                        Attachments = new[] {pluginDataAttachment}
+                            .Concat(attachmentEntries.Select(LoadAttachment))
                             .ToList()
                     };
 

--- a/src/FieldVisitHotFolderService/Readme.md
+++ b/src/FieldVisitHotFolderService/Readme.md
@@ -21,7 +21,7 @@ When you upgrade your AQTS app server, it is recommended that you use the most r
 
 | AQTS Version | Latest compatible service version |
 | --- | --- |
-| AQTS 2019.4 Update 1 | [v19.4.3](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/FieldVisitHotFolderService.zip) |
+| AQTS 2019.4 Update 1 | [v19.4.4](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/FieldVisitHotFolderService.zip) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/FieldVisitHotFolderService.zip) |
 | AQTS 2019.3 | [v19.3.3](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.3.3/FieldVisitHotFolderService.zip) |
 | AQTS 2019.2 | [v19.2.2](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.2.2/FieldVisitHotFolderService.zip) |

--- a/src/JsonFieldData/Readme.md
+++ b/src/JsonFieldData/Readme.md
@@ -16,7 +16,7 @@ When you install the JSON plugin on your AQTS app server, it is recommended that
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2019.4 Update 1 | [v19.4.3](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/JsonFieldData.plugin) |
+| AQTS 2019.4 Update 1 | [v19.4.4](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/JsonFieldData.plugin) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/JsonFieldData.plugin) |
 | AQTS 2019.3 | [v19.3.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.3.0/JsonFieldData.plugin) |
 | AQTS 2019.2 | [v19.2.2](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.2.2/JsonFieldData.plugin) |

--- a/src/MultiFile/Readme.md
+++ b/src/MultiFile/Readme.md
@@ -23,7 +23,7 @@ When you install the MultiFile plugin on your AQTS app server, it is recommended
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2019.4 Update 1 | [v19.4.3](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/MultiFile.plugin) |
+| AQTS 2019.4 Update 1 | [v19.4.4](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.3/MultiFile.plugin) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/MultiFile.plugin) |
 | AQTS 2019.3 | [v19.3.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.3.0/MultiFile.plugin) |
 | AQTS 2019.2 | [v19.2.2](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.2.2/MultiFile.plugin) |


### PR DESCRIPTION
1) Ensure the original plugin data file is attached to the uploaded ZIP

2) When uploading a ZIP archive, ensure the name of the uploaded file has a ".zip" extension