### PR TITLE
PF-697 - Add a unit test that ensures the entire AppendedResults DTO …

### DIFF
--- a/src/FieldDataPluginFramework.Serialization.UnitTests/FieldDataPluginFramework.Serialization.UnitTests.csproj
+++ b/src/FieldDataPluginFramework.Serialization.UnitTests/FieldDataPluginFramework.Serialization.UnitTests.csproj
@@ -34,6 +34,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.12.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.12.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="Fare, Version=2.1.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fare.2.1.1\lib\net35\Fare.dll</HintPath>
+    </Reference>
     <Reference Include="FieldDataPluginFramework, Version=2.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Library\FieldDataPluginFramework.dll</HintPath>
@@ -48,6 +54,7 @@
       <HintPath>..\packages\ServiceStack.Text.4.5.14\lib\net45\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />

--- a/src/FieldDataPluginFramework.Serialization.UnitTests/packages.config
+++ b/src/FieldDataPluginFramework.Serialization.UnitTests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoFixture" version="4.12.0" targetFramework="net472" />
+  <package id="Fare" version="2.1.1" targetFramework="net472" />
   <package id="FluentAssertions" version="5.6.0" targetFramework="net472" />
   <package id="NUnit" version="3.11.0" targetFramework="net472" />
   <package id="ServiceStack.Text" version="4.5.14" targetFramework="net472" />


### PR DESCRIPTION
…can roundtrip via JSON

Had this test been in place for AQTS 2019.2, we would have caught that inspections and calibrations were not being deserialized.