### PR TITLE
PF-713 - Fixed a deserialization bug for EngineeredStructureDischarge

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the field data framework.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-field-data-framework/compare/v17.4.1...v17.4.0) to see the full source code difference.
 
+### 20.3.1
+- Fixed a serialization bug for Engineered structures
+
 ### 20.3.0
 - Added support for AQTS 2020.3 plugins.
 - See [2020.3 release notes](docs#aqts-20203---framework-version-210) for details of new features.

--- a/src/FieldVisitHotFolderService/Readme.md
+++ b/src/FieldVisitHotFolderService/Readme.md
@@ -21,7 +21,7 @@ When you upgrade your AQTS app server, it is recommended that you use the most r
 
 | AQTS Version | Latest compatible service version |
 | --- | --- |
-| AQTS 2020.3 | [v20.3.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.0/FieldVisitHotFolderService.zip) |
+| AQTS 2020.3 | [v20.3.1](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.1/FieldVisitHotFolderService.zip) |
 | AQTS 2020.2 | [v20.2.5](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.2.5/FieldVisitHotFolderService.zip) |
 | AQTS 2020.1<br/>AQTS 2019.4 Update 1 | [v19.4.14](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.14/FieldVisitHotFolderService.zip) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/FieldVisitHotFolderService.zip) |

--- a/src/JsonFieldData/Readme.md
+++ b/src/JsonFieldData/Readme.md
@@ -16,7 +16,7 @@ When you install the JSON plugin on your AQTS app server, it is recommended that
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2020.3 | [v20.3.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.0/JsonFieldData.plugin) |
+| AQTS 2020.3 | [v20.3.1](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.1/JsonFieldData.plugin) |
 | AQTS 2020.2 | [v20.2.5](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.2.5/JsonFieldData.plugin) |
 | AQTS 2020.1<br/>AQTS 2019.4 Update 1 | [v19.4.14](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.14/JsonFieldData.plugin) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/JsonFieldData.plugin) |

--- a/src/MultiFile/Readme.md
+++ b/src/MultiFile/Readme.md
@@ -23,7 +23,7 @@ When you install the MultiFile plugin on your AQTS app server, it is recommended
 
 | AQTS Version | Latest compatible plugin Version |
 | --- | --- |
-| AQTS 2020.3 | [v20.3.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.0/MultiFile.plugin) |
+| AQTS 2020.3 | [v20.3.1](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.3.1/MultiFile.plugin) |
 | AQTS 2020.2 | [v20.2.5](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v20.2.5/MultiFile.plugin) |
 | AQTS 2020.1<br/>AQTS 2019.4 Update 1 | [v19.4.14](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.14/MultiFile.plugin) |
 | AQTS 2019.4 | [v19.4.0](https://github.com/AquaticInformatics/aquarius-field-data-framework/releases/download/v19.4.0/MultiFile.plugin) |


### PR DESCRIPTION
Use the presence of the EngineeredStructureType property to determine that the channel measurement is an EngineeredStructureDischarge.

@MartinBenn-AI I realized that I chose the wrong mandatory property for an engineered structure. So I cleaned that up a bit.