### PR TITLE
PF-713 - Improved error logging for FieldVisitHotFolderService

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the field data framework.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-field-data-framework/compare/v17.4.1...v17.4.0) to see the full source code difference.
 
+### 20.3.2
+- FieldVisitHotFolderService - Improved error logging.
+
 ### 20.3.1
 - Fixed a serialization bug for Engineered structures
 

--- a/src/FieldVisitHotFolderService/Program.cs
+++ b/src/FieldVisitHotFolderService/Program.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Common;
 using log4net;
+using ServiceStack;
 
 namespace FieldVisitHotFolderService
 {
@@ -31,13 +32,35 @@ namespace FieldVisitHotFolderService
                 Log.Info("Successful exit.");
                 Environment.ExitCode = 0;
             }
-            catch (ExpectedException ex)
+            catch (Exception exception)
             {
-                Log.Error(ex.Message);
+                LogException(exception);
             }
-            catch (Exception ex)
+        }
+
+        private static bool LogException(Exception exception)
+        {
+            switch (exception)
             {
-                Log.Error(ex);
+                case WebServiceException webServiceException:
+                    Log.Error($"{webServiceException.ErrorCode} {webServiceException.ErrorMessage}");
+                    return true;
+
+                case OperationCanceledException _:
+                    Log.Error("Operation cancelled.");
+                    return true;
+
+                case ExpectedException _:
+                    Log.Error(exception.Message);
+                    return true;
+
+                case AggregateException aggregateException:
+                    aggregateException.Handle(LogException);
+                    return true;
+
+                default:
+                    Log.Error(exception);
+                    return false;
             }
         }
 

--- a/src/FieldVisitHotFolderService/log4net.config
+++ b/src/FieldVisitHotFolderService/log4net.config
@@ -8,7 +8,7 @@
     </mapping>
     <mapping>
       <level value="ERROR" />
-      <foreColor value="Red" />
+      <foreColor value="Red, HighIntensity" />
     </mapping>
     <mapping>
       <level value="WARN" />


### PR DESCRIPTION
1) log4net configuration uses high intensity red error messages for better readability.

2) Handle aggregate exceptions at the outer layer