### PR TITLE
AT-2451 Publish net10 framework and re-order folders

### DIFF
--- a/src/Aquarius.FieldDataFramework.nuspec
+++ b/src/Aquarius.FieldDataFramework.nuspec
@@ -42,9 +42,10 @@
 
     <files>
         <file src="Library\FieldDataPluginFramework.dll" target="lib\net472" />
-        <file src="PluginPackager\bin\Release\net472\PluginPackager.exe" target="tools" />
+        <file src="Library\FieldDataPluginFramework.dll" target="lib\net10.0" />
+        <file src="PluginPackager\bin\Release\net472\PluginPackager.exe" target="tools\net472" />
         <file src="PluginPackager\bin\Release\net10.0\**" target="tools\net10.0" />
-        <file src="PluginTester\bin\Release\net472\PluginTester.exe" target="tools" />
+        <file src="PluginTester\bin\Release\net472\PluginTester.exe" target="tools\net472" />
         <!-- exclude: already copied from PluginPackager\net10.0 above (identical shared dependencies) -->
         <file src="PluginTester\bin\Release\net10.0\**" target="tools\net10.0" exclude="**\Common.dll;**\Common.pdb;**\FieldDataPluginFramework.dll;**\log4net.dll;**\ServiceStack.Text.dll;**\System.Configuration.ConfigurationManager.dll;**\System.Security.Cryptography.ProtectedData.dll;**\System.Security.Permissions.dll;**\runtimes\**" />
     </files>


### PR DESCRIPTION
@AquaticInformatics/artemis 

I did a boo-boo and published the tools - but not the assembly :/

Publishes the FieldDataPluginFramework.dll in net10, and also qualifies the existing net472 tools to match the path of the new net10 tools for consistency